### PR TITLE
Use CacheInformers for syncs.

### DIFF
--- a/internal/ingressmonitor/operator.go
+++ b/internal/ingressmonitor/operator.go
@@ -13,15 +13,19 @@ import (
 	"github.com/jelmersnoeck/ingress-monitor/internal/provider"
 	"github.com/jelmersnoeck/ingress-monitor/pkg/client/generated/clientset/versioned"
 	crdscheme "github.com/jelmersnoeck/ingress-monitor/pkg/client/generated/clientset/versioned/scheme"
+	tv1alpha1 "github.com/jelmersnoeck/ingress-monitor/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1"
 	"github.com/jelmersnoeck/ingress-monitor/pkg/client/generated/informers/externalversions"
+	lv1alpha1 "github.com/jelmersnoeck/ingress-monitor/pkg/client/generated/listers/ingressmonitor/v1alpha1"
 
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	ev1beta1 "k8s.io/client-go/listers/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -40,13 +44,29 @@ var encoder = base32.HexEncoding.WithPadding(base32.NoPadding)
 // Operator is the operator that handles configuring the Monitors.
 type Operator struct {
 	kubeClient kubernetes.Interface
-	imClient   versioned.Interface
+	imClient   tv1alpha1.IngressmonitorV1alpha1Interface
 
-	imInformer      externalversions.SharedInformerFactory
 	providerFactory provider.FactoryInterface
+
+	imInformer   cache.SharedIndexInformer
+	mInformer    cache.SharedIndexInformer
+	ingInformer  cache.SharedIndexInformer
+	provInformer cache.SharedIndexInformer
+	mtInformer   cache.SharedIndexInformer
+
+	informers []namedInformer
+
+	ingLister  ev1beta1.IngressLister
+	provLister lv1alpha1.ProviderLister
+	mtLister   lv1alpha1.MonitorTemplateLister
 
 	monitorQueue        workqueue.RateLimitingInterface
 	ingressMonitorQueue workqueue.RateLimitingInterface
+}
+
+type namedInformer struct {
+	name     string
+	informer cache.SharedIndexInformer
 }
 
 // NewOperator sets up a new IngressMonitor Operator which will watch for
@@ -59,18 +79,40 @@ func NewOperator(
 	// Register the scheme with the client so we can use it through the API
 	crdscheme.AddToScheme(scheme.Scheme)
 
+	imInformer := externalversions.NewSharedInformerFactory(imc, resync).Ingressmonitor().V1alpha1()
+	k8sInformer := informers.NewSharedInformerFactory(kc, resync)
+
 	op := &Operator{
 		kubeClient:          kc,
-		imClient:            imc,
-		imInformer:          externalversions.NewSharedInformerFactory(imc, resync),
+		imClient:            imc.Ingressmonitor(),
 		providerFactory:     providerFactory,
 		monitorQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Monitors"),
 		ingressMonitorQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "IngressMonitors"),
+
+		imInformer:   imInformer.IngressMonitors().Informer(),
+		mInformer:    imInformer.Monitors().Informer(),
+		provInformer: imInformer.Providers().Informer(),
+		mtInformer:   imInformer.MonitorTemplates().Informer(),
+
+		ingInformer: k8sInformer.Extensions().V1beta1().Ingresses().Informer(),
 	}
 
 	// Add EventHandlers for all objects we want to track
-	op.imInformer.Ingressmonitor().V1alpha1().Monitors().Informer().AddEventHandler(op)
-	op.imInformer.Ingressmonitor().V1alpha1().IngressMonitors().Informer().AddEventHandler(op)
+	op.imInformer.AddEventHandler(op)
+	op.mInformer.AddEventHandler(op)
+
+	// set up listers
+	op.ingLister = ev1beta1.NewIngressLister(op.ingInformer.GetIndexer())
+	op.provLister = lv1alpha1.NewProviderLister(op.provInformer.GetIndexer())
+	op.mtLister = lv1alpha1.NewMonitorTemplateLister(op.mtInformer.GetIndexer())
+
+	op.informers = []namedInformer{
+		{"IngressMonitor", op.imInformer},
+		{"Monitor", op.mInformer},
+		{"Ingress", op.ingInformer},
+		{"Provider", op.provInformer},
+		{"MonitorTemplate", op.mtInformer},
+	}
 
 	return op, nil
 }
@@ -81,9 +123,14 @@ func (o *Operator) Run(stopCh <-chan struct{}) error {
 	defer o.ingressMonitorQueue.ShutDown()
 
 	log.Printf("Starting IngressMonitor Operator")
+	if err := o.connectToCluster(stopCh); err != nil {
+		return err
+	}
 
 	log.Printf("Starting the informers")
-	o.imInformer.Start(stopCh)
+	if err := o.startInformers(stopCh); err != nil {
+		return err
+	}
 
 	log.Printf("Starting the workers")
 	for i := 0; i < 4; i++ {
@@ -93,6 +140,64 @@ func (o *Operator) Run(stopCh <-chan struct{}) error {
 
 	<-stopCh
 	log.Printf("Stopping IngressMonitor Operator")
+
+	return nil
+}
+
+func (o *Operator) connectToCluster(stopCh <-chan struct{}) error {
+	errCh := make(chan error)
+	go func() {
+		v, err := o.kubeClient.Discovery().ServerVersion()
+		if err != nil {
+			errCh <- fmt.Errorf("Could not communicate with the server: %s", err)
+			return
+		}
+
+		log.Printf("Connected to the cluster (version %s)", v)
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return err
+		}
+	case <-stopCh:
+		return nil
+	}
+
+	return nil
+}
+
+func (o *Operator) startInformers(stopCh <-chan struct{}) error {
+	for _, inf := range o.informers {
+		log.Printf("Starting informer %s", inf.name)
+		go inf.informer.Run(stopCh)
+	}
+
+	if err := o.waitForCaches(stopCh); err != nil {
+		return err
+	}
+
+	log.Printf("Synced all caches")
+	return nil
+}
+
+func (o *Operator) waitForCaches(stopCh <-chan struct{}) error {
+	var syncFailed bool
+	for _, inf := range o.informers {
+		log.Printf("Waiting for cache sync for %s", inf.name)
+		if !cache.WaitForCacheSync(stopCh, inf.informer.HasSynced) {
+			log.Printf("Could not sync cache for %s", inf.name)
+			syncFailed = true
+		} else {
+			log.Printf("Synced cache for %s", inf.name)
+		}
+	}
+
+	if syncFailed {
+		return fmt.Errorf("could not sync cache")
+	}
 
 	return nil
 }
@@ -204,7 +309,7 @@ func (o *Operator) OnDelete(obj interface{}) {
 			return
 		}
 	case *v1alpha1.Monitor:
-		imList, err := o.imClient.Ingressmonitor().IngressMonitors(obj.Namespace).
+		imList, err := o.imClient.IngressMonitors(obj.Namespace).
 			List(listOptions(map[string]string{monitorLabel: obj.Name}))
 		if err != nil {
 			log.Printf("Could not list IngressMonitors for Monitors %s:%s: %s", obj.Namespace, obj.Name, err)
@@ -213,7 +318,7 @@ func (o *Operator) OnDelete(obj interface{}) {
 
 		for _, im := range imList.Items {
 			log.Printf("Deleting IngressMonitor `%s:%s` associated with deleted Monitor `%s:%s`", im.Namespace, im.Name, obj.Namespace, obj.Name)
-			if err := o.imClient.Ingressmonitor().IngressMonitors(obj.Namespace).
+			if err := o.imClient.IngressMonitors(obj.Namespace).
 				Delete(im.Name, &metav1.DeleteOptions{}); err != nil {
 				log.Printf("Could not delete IngressMonitor %s for Monitors %s:%s: %s", im.Name, obj.Namespace, obj.Name, err)
 			}
@@ -224,17 +329,17 @@ func (o *Operator) OnDelete(obj interface{}) {
 // handleIngressMonitor handles IngressMonitors in a way that it knows how to
 // deal with creating and updating resources.
 func (o *Operator) handleIngressMonitor(key string) error {
-	// Convert the namespace/name string into a distinct namespace and name
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return fmt.Errorf("Invalid Resource Key for IngressMonitor: %s", key)
-	}
-
-	obj, err := o.imClient.Ingressmonitor().IngressMonitors(namespace).
-		Get(name, metav1.GetOptions{})
+	item, exists, err := o.imInformer.GetIndexer().GetByKey(key)
 	if err != nil {
 		return err
 	}
+
+	// it's been deleted before we start handling it
+	if !exists {
+		return nil
+	}
+
+	obj := item.(*v1alpha1.IngressMonitor)
 
 	cl, err := o.providerFactory.From(obj.Spec.Provider)
 	if err != nil {
@@ -258,7 +363,7 @@ func (o *Operator) handleIngressMonitor(key string) error {
 	// will be present, and thus create a new one.
 	if obj.Status.ID != id {
 		obj.Status.ID = id
-		_, err = o.imClient.Ingressmonitor().IngressMonitors(obj.Namespace).Update(obj)
+		_, err = o.imClient.IngressMonitors(obj.Namespace).Update(obj)
 	}
 
 	return err
@@ -272,10 +377,14 @@ func (o *Operator) handleIngressMonitor(key string) error {
 // If one of the monitors isn't linked to the Ingress, it gets marked for
 // deletion.
 func (o *Operator) garbageCollectMonitors(obj *v1alpha1.Monitor) error {
-	ingressList, err := o.kubeClient.Extensions().Ingresses(obj.Namespace).
-		List(listOptions(obj.Spec.Selector.MatchLabels))
+	ingLabels, err := metav1.LabelSelectorAsSelector(obj.Spec.Selector)
 	if err != nil {
-		return err
+		return fmt.Errorf("Could not create label selector for %s:%s: %s", obj.Namespace, obj.Name, err)
+	}
+
+	ingressList, err := o.ingLister.Ingresses(obj.Namespace).List(ingLabels)
+	if err != nil {
+		return fmt.Errorf("Could not list Ingresses: %s", err)
 	}
 
 	// We'll calculate all the IngressMonitors that shouldn't be tracked
@@ -283,12 +392,9 @@ func (o *Operator) garbageCollectMonitors(obj *v1alpha1.Monitor) error {
 	// IngressMonitors where the owner is this Monitor, go over them all and
 	// see if there are any where the Ingress Owner isn't in the new Ingress
 	// List.
-	imList, err := o.imClient.Ingressmonitor().IngressMonitors(obj.Namespace).
-		List(listOptions(map[string]string{monitorLabel: obj.Name}))
-	if err != nil {
-		return err
-	}
-	for _, im := range imList.Items {
+	imLabels := labels.SelectorFromSet(map[string]string{monitorLabel: obj.Name})
+	cache.ListAllByNamespace(o.imInformer.GetIndexer(), obj.Namespace, imLabels, func(imObj interface{}) {
+		im := imObj.(*v1alpha1.IngressMonitor)
 		var isActive bool
 
 		// Go through all newly selected Ingresses and see if this
@@ -296,8 +402,8 @@ func (o *Operator) garbageCollectMonitors(obj *v1alpha1.Monitor) error {
 		// validating if it's controlled by the Ingress, and if so we check if
 		// it matches any of the rules. Ingresses might change which means a
 		// specific rule can be dropped. We need to GC that.
-		for _, ing := range ingressList.Items {
-			if metav1.IsControlledBy(&im, &ing) {
+		for _, ing := range ingressList {
+			if metav1.IsControlledBy(im, ing) {
 				for _, rule := range ing.Spec.Rules {
 					if rule.Host == im.Labels[ingressHostLabel] {
 						isActive = true
@@ -312,58 +418,63 @@ func (o *Operator) garbageCollectMonitors(obj *v1alpha1.Monitor) error {
 		// reconciliation to take care of actually removing the monitor with the
 		// provider.
 		if !isActive {
-			log.Printf("Deleting IngressMonitor %s:%s with GC", obj.Namespace, im.Name)
-			if err := o.imClient.Ingressmonitor().IngressMonitors(obj.Namespace).
+			log.Printf("Deleting IngressMonitor %s:%s with GC", im.Namespace, im.Name)
+			if err := o.imClient.IngressMonitors(im.Namespace).
 				Delete(im.Name, &metav1.DeleteOptions{}); err != nil {
-				return err
+
+				log.Printf("Could not delete IngressMonitor %s:%s: %s", im.Namespace, im.Name, err)
 			}
 		}
-	}
+	})
 
 	return nil
 }
 
 func (o *Operator) handleMonitor(key string) error {
-	// Convert the namespace/name string into a distinct namespace and name
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return fmt.Errorf("Invalid Resource Key for Monitor: %s", key)
-	}
-
-	obj, err := o.imClient.Ingressmonitor().Monitors(namespace).
-		Get(name, metav1.GetOptions{})
+	item, exists, err := o.mInformer.GetIndexer().GetByKey(key)
 	if err != nil {
 		return err
 	}
 
+	// it's been deleted before we start handling it
+	if !exists {
+		return nil
+	}
+
+	obj := item.(*v1alpha1.Monitor)
 	if err := o.garbageCollectMonitors(obj); err != nil {
 		return fmt.Errorf("Error doing garbage collection for %s:%s: %s", obj.Namespace, obj.Name, err)
 	}
 
-	ingressList, err := o.kubeClient.Extensions().Ingresses(obj.Namespace).
-		List(listOptions(obj.Spec.Selector.MatchLabels))
+	ingLabels, err := metav1.LabelSelectorAsSelector(obj.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("Could not create label selector for %s:%s: %s", obj.Namespace, obj.Name, err)
+	}
+
+	ingressList, err := o.ingLister.Ingresses(obj.Namespace).List(ingLabels)
 	if err != nil {
 		return fmt.Errorf("Could not list Ingresses: %s", err)
 	}
 
-	// fetch the referenced provider
-	prov, err := o.imClient.Ingressmonitor().Providers(obj.Namespace).
-		Get(obj.Spec.Provider.Name, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("Could not get Provider: %s", err)
+	if len(ingressList) == 0 {
+		log.Printf("No ingresses selected for %s:%s", obj.Namespace, obj.Name)
+		return nil
 	}
 
-	// fetch the referenced template
-	tmpl, err := o.imClient.Ingressmonitor().MonitorTemplates(obj.Namespace).
-		Get(obj.Spec.Template.Name, metav1.GetOptions{})
+	prov, err := o.provLister.Providers(obj.Namespace).Get(obj.Spec.Provider.Name)
 	if err != nil {
-		return fmt.Errorf("Could not get MonitorTemplate: %s", err)
+		return fmt.Errorf("Could not get Provider %s:%s: %s", obj.Namespace, obj.Spec.Provider.Name, err)
+	}
+
+	tmpl, err := o.mtLister.MonitorTemplates(obj.Namespace).Get(obj.Spec.Template.Name)
+	if err != nil {
+		return fmt.Errorf("Could not get MonitorTemplate %s: %s", obj.Spec.Template.Name, err)
 	}
 
 	// reconcile the newly selected Ingresses. We'll create new IngressMonitors
 	// for each Ingress and it's subsequent rules. If it already exists, we
 	// update it.
-	for _, ing := range ingressList.Items {
+	for _, ing := range ingressList {
 		for _, rule := range ing.Spec.Rules {
 			name := fmt.Sprintf("%s-%s", ing.Name, shortHash(rule.Host, 16))
 
@@ -412,7 +523,7 @@ func (o *Operator) handleMonitor(key string) error {
 					// have to set this up ourselves.
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(
-							&ing,
+							ing,
 							extensions.SchemeGroupVersion.WithKind("Ingress"),
 						),
 						monitorReference,
@@ -433,19 +544,17 @@ func (o *Operator) handleMonitor(key string) error {
 				},
 			}
 
-			gIM, err := o.imClient.Ingressmonitor().IngressMonitors(im.Namespace).
+			gIM, err := o.imClient.IngressMonitors(im.Namespace).
 				Get(im.Name, metav1.GetOptions{})
 			if errors.IsNotFound(err) {
-				_, err = o.imClient.Ingressmonitor().
-					IngressMonitors(im.Namespace).Create(im)
+				_, err = o.imClient.IngressMonitors(im.Namespace).Create(im)
 			} else if err == nil {
 				im.ObjectMeta = gIM.ObjectMeta
 				im.TypeMeta = gIM.TypeMeta
 				im.Status = gIM.Status
 				im.Status.IngressName = ing.Name
 
-				_, err = o.imClient.Ingressmonitor().
-					IngressMonitors(im.Namespace).Update(im)
+				_, err = o.imClient.IngressMonitors(im.Namespace).Update(im)
 			}
 
 			if err != nil {
@@ -474,7 +583,7 @@ func shortHash(data string, len int) string {
 	return strings.ToLower(encoder.EncodeToString(b2b.Sum(nil)))
 }
 
-func templatedName(ing v1beta1.Ingress, sp v1alpha1.MonitorTemplateSpec) (string, error) {
+func templatedName(ing *v1beta1.Ingress, sp v1alpha1.MonitorTemplateSpec) (string, error) {
 	tpl, err := template.New("im-name").Parse(sp.Name)
 	if err != nil {
 		return "", err

--- a/internal/ingressmonitor/operator.go
+++ b/internal/ingressmonitor/operator.go
@@ -3,6 +3,7 @@ package ingressmonitor
 import (
 	"bytes"
 	"encoding/base32"
+	"errors"
 	"fmt"
 	"html/template"
 	"log"
@@ -39,7 +40,10 @@ const (
 	ingressHostLabel = "ingressmonitor.sphc.io/ingress-path"
 )
 
-var encoder = base32.HexEncoding.WithPadding(base32.NoPadding)
+var (
+	errCouldNotSyncCache = errors.New("could not sync caches")
+	encoder              = base32.HexEncoding.WithPadding(base32.NoPadding)
+)
 
 // Operator is the operator that handles configuring the Monitors.
 type Operator struct {
@@ -196,7 +200,7 @@ func (o *Operator) waitForCaches(stopCh <-chan struct{}) error {
 	}
 
 	if syncFailed {
-		return fmt.Errorf("could not sync cache")
+		return errCouldNotSyncCache
 	}
 
 	return nil

--- a/internal/ingressmonitor/operator.go
+++ b/internal/ingressmonitor/operator.go
@@ -18,7 +18,7 @@ import (
 	lv1alpha1 "github.com/jelmersnoeck/ingress-monitor/pkg/client/generated/listers/ingressmonitor/v1alpha1"
 
 	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -546,7 +546,7 @@ func (o *Operator) handleMonitor(key string) error {
 
 			gIM, err := o.imClient.IngressMonitors(im.Namespace).
 				Get(im.Name, metav1.GetOptions{})
-			if errors.IsNotFound(err) {
+			if kerrors.IsNotFound(err) {
 				_, err = o.imClient.IngressMonitors(im.Namespace).Create(im)
 			} else if err == nil {
 				im.ObjectMeta = gIM.ObjectMeta

--- a/internal/ingressmonitor/operator_test.go
+++ b/internal/ingressmonitor/operator_test.go
@@ -1,162 +1,325 @@
 package ingressmonitor
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/jelmersnoeck/ingress-monitor/apis/ingressmonitor/v1alpha1"
 	"github.com/jelmersnoeck/ingress-monitor/internal/provider"
-	"github.com/jelmersnoeck/ingress-monitor/internal/provider/fake"
-	"github.com/jelmersnoeck/ingress-monitor/pkg/client/generated/clientset/versioned"
 	imfake "github.com/jelmersnoeck/ingress-monitor/pkg/client/generated/clientset/versioned/fake"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
-func TestOperator_HandleNextItem(t *testing.T) {
-	op, _ := NewOperator(nil, nil, "", time.Minute, nil)
-	var queue workqueue.RateLimitingInterface
-	setup := func() {
-		queue = workqueue.NewNamedRateLimitingQueue(
-			workqueue.NewItemExponentialFailureRateLimiter(0, 0),
-			"Tests",
-		)
-	}
+func TestOperator_SyncIngressMonitor(t *testing.T) {
+	t.Run("without configured provider", func(t *testing.T) {
+		op := newOperator(t)
 
-	t.Run("with a shut down queue", func(t *testing.T) {
-		setup()
-
-		queue.ShutDown()
-
-		if op.handleNextItem("test", queue, nil) {
-			t.Errorf("Expected not to want to handle next item, got true")
-		}
+		im := newIngressMonitor()
+		expError := fmt.Errorf("Error fetching provider 'simple': the specified provider can't be found")
+		errEquals(t, expError, op.handleIngressMonitor(t, im))
 	})
 
-	t.Run("with a non string object in the queue", func(t *testing.T) {
-		setup()
-
-		queue.Add(struct{}{})
-
-		if queue.Len() != 1 {
-			t.Fatalf("Expected 1 item to be added to the queue")
-		}
-
-		if !op.handleNextItem("test", queue, nil) {
-			t.Errorf("Expected to want to proceed processing objects")
-		}
-
-		if queue.Len() != 0 {
-			t.Errorf("Expected object to be removed from the queue")
-		}
-	})
-
-	t.Run("with an error handling the object", func(t *testing.T) {
-		setup()
-
-		queue.Add("12345")
-
-		if queue.Len() != 1 {
-			t.Fatalf("Expected 1 item to be added to the queue")
-		}
-
-		handler := func(id string) error {
-			if id != "12345" {
-				t.Errorf("Expected ID to match, got %s", id)
-			}
-
-			return errors.New("not handled")
-		}
-
-		if !op.handleNextItem("test", queue, handler) {
-			t.Errorf("Expected to want to proceed processing objects")
-		}
-
-		if queue.Len() != 0 {
-			t.Errorf("Expected object to be removed from the queue")
-		}
+	t.Run("with provider configured", func(t *testing.T) {
+		t.Run("resyncing an existing ingress monitor", func(t *testing.T) {
+		})
 	})
 }
 
-func TestOperator_OnAddUpdate_IngressMonitor(t *testing.T) {
-	crd := &v1alpha1.IngressMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-im",
-			Namespace: "testing",
-		},
-		Spec: v1alpha1.IngressMonitorSpec{
-			Provider: v1alpha1.NamespacedProvider{
-				Namespace: "testing",
-				ProviderSpec: v1alpha1.ProviderSpec{
-					Type: "simple",
-				},
-			},
-		},
+func TestOperator_SyncMonitor(t *testing.T) {
+	t.Run("without matching ingresses", func(t *testing.T) {
+		op := newOperator(t)
+
+		mon := newMonitor()
+		errEquals(t, nil, op.handleMonitor(t, mon))
+	})
+
+	t.Run("without existing provider", func(t *testing.T) {
+		op := newOperator(t, withIngresses(newIngress()))
+
+		mon := newMonitor()
+		expError := fmt.Errorf("Could not get Provider testing:test-provider: provider.ingressmonitor.sphc.io \"test-provider\" not found")
+		errEquals(t, expError, op.handleMonitor(t, mon))
+	})
+
+	t.Run("without existing template", func(t *testing.T) {
+		op := newOperator(t,
+			withIngresses(newIngress()),
+			withProviders(newProvider()),
+		)
+
+		mon := newMonitor()
+		expError := fmt.Errorf("Could not get MonitorTemplate test-template: monitortemplate.ingressmonitor.sphc.io \"test-template\" not found")
+		errEquals(t, expError, op.handleMonitor(t, mon))
+	})
+
+	t.Run("with an ingress provider and template should create an IngressMonitor", func(t *testing.T) {
+		op := newOperator(t,
+			withIngresses(newIngress()),
+			withProviders(newProvider()),
+			withTemplates(newTemplate()),
+		)
+
+		stopCh := make(chan struct{})
+		op.op.startInformers(stopCh)
+
+		defer func() {
+			stopCh <- struct{}{}
+		}()
+
+		mon := newMonitor()
+		errEquals(t, nil, op.handleMonitor(t, mon), "creating a new monitor")
+
+		imList, err := op.op.imClient.IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
+		errEquals(t, nil, err, "listing the IngressMonitors")
+
+		if len(imList.Items) != 1 {
+			t.Errorf("Expected 1 IngressMonitor to be created")
+		}
+
+		im := imList.Items[0]
+
+		expName := "test-go-ingress-testing"
+		strEquals(t, expName, im.Spec.Template.Name)
+
+		expURL := "https://api.example.com/test-healthz"
+		strEquals(t, expURL, im.Spec.Template.HTTP.URL)
+	})
+
+	t.Run("updating an existing monitor", func(t *testing.T) {
+		var op *operatorWrapper
+		var stopCh chan struct{}
+		setup := func() {
+			op = newOperator(t,
+				withIngresses(newIngress()),
+				withProviders(newProvider()),
+				withTemplates(newTemplate()),
+			)
+
+			// ensure that the monitor is added corectly
+			errEquals(t, nil, op.handleMonitor(t, newMonitor()))
+
+			stopCh = make(chan struct{})
+			op.op.startInformers(stopCh)
+		}
+
+		cleanup := func() {
+			stopCh <- struct{}{}
+		}
+
+		t.Run("changing labels", func(t *testing.T) {
+			setup()
+			defer cleanup()
+
+			mon := newMonitor()
+
+			imList, err := op.op.imClient.IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
+			errEquals(t, nil, err)
+
+			if len(imList.Items) != 1 {
+				t.Errorf("Expected 1 IngressMonitor to be available, got %d", len(imList.Items))
+			}
+
+			mon.Spec.Selector.MatchLabels["non-existing-key"] = "fake-value"
+			errEquals(t, nil, op.handleMonitor(t, mon))
+
+			imList, err = op.op.imClient.IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
+			errEquals(t, nil, err)
+
+			if len(imList.Items) != 0 {
+				t.Errorf("Expected 0 IngressMonitor to be available, got %d", len(imList.Items))
+			}
+		})
+
+		t.Run("adding an ingress and resyncing", func(t *testing.T) {
+			setup()
+			defer cleanup()
+
+			ing := newIngress()
+			ing.Name = "new-ingress"
+			newRule := v1beta1.IngressRule{
+				Host: "new.api.example.com",
+			}
+			ing.Spec.Rules = append(ing.Spec.Rules, newRule)
+			op.addIngress(ing)
+
+			// trigger resync
+			mon := newMonitor()
+			errEquals(t, nil, op.handleMonitor(t, mon))
+
+			imList, err := op.op.imClient.IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
+			errEquals(t, nil, err)
+
+			if len(imList.Items) != 3 {
+				t.Errorf("Expected 3 IngressMonitors to be available, got %d", len(imList.Items))
+			}
+		})
+	})
+}
+
+type operatorWrapper struct {
+	op         *Operator
+	kubeClient *k8sfake.Clientset
+	imClient   *imfake.Clientset
+}
+
+type operatorConfig struct {
+	ingresses   []runtime.Object
+	kubeObjects []runtime.Object
+
+	providers  []runtime.Object
+	templates  []runtime.Object
+	monitors   []runtime.Object
+	crdObjects []runtime.Object
+}
+
+type optionFunc func(*operatorConfig)
+
+func withIngresses(obj ...runtime.Object) optionFunc {
+	return func(op *operatorConfig) {
+		op.ingresses = append(op.ingresses, obj...)
+		op.kubeObjects = append(op.kubeObjects, obj...)
+	}
+}
+
+func withProviders(obj ...runtime.Object) optionFunc {
+	return func(op *operatorConfig) {
+		op.providers = append(op.providers, obj...)
+		op.crdObjects = append(op.crdObjects, obj...)
+	}
+}
+
+func withTemplates(obj ...runtime.Object) optionFunc {
+	return func(op *operatorConfig) {
+		op.templates = append(op.templates, obj...)
+		op.crdObjects = append(op.crdObjects, obj...)
+	}
+}
+
+func withMonitors(obj ...runtime.Object) optionFunc {
+	return func(op *operatorConfig) {
+		op.monitors = append(op.monitors, obj...)
+		op.crdObjects = append(op.crdObjects, obj...)
+	}
+}
+
+func newOperator(t *testing.T, opts ...optionFunc) *operatorWrapper {
+	cfg := new(operatorConfig)
+	for _, opt := range opts {
+		opt(cfg)
 	}
 
-	prov := new(fake.SimpleProvider)
-	prov.CreateFunc = func(v1alpha1.MonitorTemplateSpec) (string, error) {
-		return "1234", nil
-	}
-	prov.UpdateFunc = func(id string, sp v1alpha1.MonitorTemplateSpec) (string, error) {
-		return id, nil
-	}
-
+	k8sClient := k8sfake.NewSimpleClientset(cfg.kubeObjects...)
+	crdClient := imfake.NewSimpleClientset(cfg.crdObjects...)
 	fact := provider.NewFactory(nil)
-	fact.Register("simple", fake.FactoryFunc(prov))
+	op, err := NewOperator(k8sClient, crdClient, v1.NamespaceAll, noResyncPeriodFunc(), fact)
+	if err != nil {
+		t.Fatalf("Error creating the operator: %s", err)
+	}
 
-	crdClient := imfake.NewSimpleClientset(crd)
-	op, _ := NewOperator(nil, crdClient, "", time.Minute, fact)
 	op.ingressMonitorQueue = workqueue.NewNamedRateLimitingQueue(
 		workqueue.NewItemExponentialFailureRateLimiter(0, 0),
 		"IngressMonitors",
 	)
+	op.monitorQueue = workqueue.NewNamedRateLimitingQueue(
+		workqueue.NewItemExponentialFailureRateLimiter(0, 0),
+		"Monitors",
+	)
 
-	t.Run("add ingress monitor", func(t *testing.T) {
-		op.OnAdd(crd)
+	for _, ing := range cfg.ingresses {
+		op.ingInformer.GetIndexer().Add(ing)
+	}
 
-		if op.ingressMonitorQueue.Len() != 1 {
-			t.Errorf("Expected 1 item in the queue, got %d", op.ingressMonitorQueue.Len())
-		}
+	for _, prov := range cfg.providers {
+		op.provInformer.GetIndexer().Add(prov)
+	}
 
-		// process the item
-		if ok := op.processNextIngressMonitor(); !ok {
-			t.Errorf("Expected IngressMonitor to be processed")
-		}
+	for _, tpl := range cfg.templates {
+		op.mtInformer.GetIndexer().Add(tpl)
+	}
 
-		if op.ingressMonitorQueue.Len() != 0 {
-			t.Errorf("Expected 0 items in the queue, got %d", op.ingressMonitorQueue.Len())
-		}
-	})
-
-	t.Run("update ingress monitor", func(t *testing.T) {
-		op.OnUpdate(crd, crd)
-
-		if op.ingressMonitorQueue.Len() != 1 {
-			t.Errorf("Expected 1 item in the queue, got %d", op.ingressMonitorQueue.Len())
-		}
-
-		// process the item
-		if ok := op.processNextIngressMonitor(); !ok {
-			t.Errorf("Expected IngressMonitor to be processed")
-		}
-
-		if op.ingressMonitorQueue.Len() != 0 {
-			t.Errorf("Expected 0 items in the queue, got %d", op.ingressMonitorQueue.Len())
-		}
-	})
+	return &operatorWrapper{op, k8sClient, crdClient}
 }
 
-func Test_OnAddUpdate_Monitor(t *testing.T) {
-	crd := &v1alpha1.Monitor{
+func (o *operatorWrapper) handleIngressMonitor(t *testing.T, mon *v1alpha1.IngressMonitor) error {
+	o.op.imInformer.GetIndexer().Add(mon)
+	return o.op.handleIngressMonitor(getKey(t, mon))
+}
+
+func (o *operatorWrapper) handleMonitor(t *testing.T, mon *v1alpha1.Monitor) error {
+	o.op.mInformer.GetIndexer().Add(mon)
+	return o.op.handleMonitor(getKey(t, mon))
+}
+
+func (o *operatorWrapper) addIngress(ing *v1beta1.Ingress) {
+	o.op.ingInformer.GetIndexer().Add(ing)
+}
+
+var noResyncPeriodFunc = func() time.Duration { return 0 }
+
+func getKey(t *testing.T, obj interface{}) string {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		t.Fatalf("Could not get namespaced key for %#v:\n\n%s", obj, err)
+	}
+
+	return key
+}
+
+func strEquals(t *testing.T, exp, act string) {
+	if exp != act {
+		t.Errorf("Expected value to be '%s', got '%s'", exp, act)
+	}
+}
+
+func errEquals(t *testing.T, exp, act error, str ...string) {
+	prefix := ""
+	for _, s := range str {
+		prefix = fmt.Sprintf("%s%s ", prefix, s)
+	}
+
+	if exp == nil && act == nil {
+		return
+	}
+
+	if exp != nil && act == nil {
+		t.Fatalf("%sexpected error %s, got none", prefix, exp)
+	}
+
+	if exp == nil && act != nil {
+		t.Fatalf("%sexpected no error, got %s", prefix, act)
+	}
+
+	if exp.Error() != act.Error() {
+		t.Fatalf("%sexpected error \n%s\ngot\n%s\n", prefix, exp, act)
+	}
+}
+
+func newTemplate() *v1alpha1.MonitorTemplate {
+	return &v1alpha1.MonitorTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-template",
+			Namespace: "testing",
+		},
+		Spec: v1alpha1.MonitorTemplateSpec{
+			Type: "HTTP",
+			HTTP: &v1alpha1.HTTPTemplate{
+				Endpoint: ptrString("/test-healthz"),
+			},
+			Name: "test-{{.IngressName}}-{{.IngressNamespace}}",
+		},
+	}
+}
+
+func newMonitor() *v1alpha1.Monitor {
+	return &v1alpha1.Monitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-monitor",
 			Namespace: "testing",
@@ -175,435 +338,10 @@ func Test_OnAddUpdate_Monitor(t *testing.T) {
 			},
 		},
 	}
-
-	prov := &v1alpha1.Provider{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-provider",
-			Namespace: "testing",
-		},
-	}
-	tpl := &v1alpha1.MonitorTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-template",
-			Namespace: "testing",
-		},
-		Spec: v1alpha1.MonitorTemplateSpec{
-			Type: "HTTP",
-			HTTP: &v1alpha1.HTTPTemplate{},
-		},
-	}
-
-	k8sClient := k8sfake.NewSimpleClientset()
-	crdClient := imfake.NewSimpleClientset(crd, prov, tpl)
-
-	fact := provider.NewFactory(nil)
-	op, _ := NewOperator(k8sClient, crdClient, "", time.Minute, fact)
-	op.monitorQueue = workqueue.NewNamedRateLimitingQueue(
-		workqueue.NewItemExponentialFailureRateLimiter(0, 0),
-		"Monitors",
-	)
-
-	t.Run("add monitor", func(t *testing.T) {
-		op.OnAdd(crd)
-
-		if op.monitorQueue.Len() != 1 {
-			t.Errorf("Expected 1 item in the queue, got %d", op.monitorQueue.Len())
-		}
-
-		// process the item
-		if ok := op.processNextMonitor(); !ok {
-			t.Errorf("Expected Monitor to be processed")
-		}
-
-		if op.monitorQueue.Len() != 0 {
-			t.Errorf("Expected 0 items in the queue, got %d", op.monitorQueue.Len())
-		}
-	})
-
-	t.Run("update monitor", func(t *testing.T) {
-		op.OnUpdate(crd, crd)
-
-		if op.monitorQueue.Len() != 1 {
-			t.Errorf("Expected 1 item in the queue, got %d", op.ingressMonitorQueue.Len())
-		}
-
-		// process the item
-		if ok := op.processNextMonitor(); !ok {
-			t.Errorf("Expected Monitor to be processed")
-		}
-
-		if op.monitorQueue.Len() != 0 {
-			t.Errorf("Expected 0 items in the queue, got %d", op.monitorQueue.Len())
-		}
-	})
 }
 
-func TestOperator_HandleIngressMonitor(t *testing.T) {
-	t.Run("creating a new test with the provider", func(t *testing.T) {
-		fact := provider.NewFactory(nil)
-
-		prov := new(fake.SimpleProvider)
-		prov.CreateFunc = func(v1alpha1.MonitorTemplateSpec) (string, error) {
-			return "1234", nil
-		}
-
-		fact.Register("simple", fake.FactoryFunc(prov))
-
-		crd := &v1alpha1.IngressMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-im",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.IngressMonitorSpec{
-				Provider: v1alpha1.NamespacedProvider{
-					Namespace: "testing",
-					ProviderSpec: v1alpha1.ProviderSpec{
-						Type: "simple",
-					},
-				},
-			},
-		}
-
-		crdClient := imfake.NewSimpleClientset(crd)
-		op, _ := NewOperator(nil, crdClient, "", time.Minute, fact)
-
-		if err := op.handleIngressMonitor(namespaceKey(t, crd)); err != nil {
-			t.Errorf("Expected no error, got %s", err)
-		}
-
-		if prov.CreateCount != 1 {
-			t.Errorf("Expected Create to be called once, got %d", prov.CreateCount)
-		}
-
-		crd, err := crdClient.Ingressmonitor().IngressMonitors(crd.Namespace).Get(crd.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Expected no error fetching the CRD, got %s", err)
-		}
-
-		if crd.Status.ID != "1234" {
-			t.Errorf("Expected status to be updated")
-		}
-	})
-
-	t.Run("with the item already deleted from the server", func(t *testing.T) {
-		// this can happen when we had to queue for a while and the item has
-		// been deleted in the meantime. We want to ensure it's handled
-		// gracefully.
-		fact := provider.NewFactory(nil)
-
-		prov := new(fake.SimpleProvider)
-		fact.Register("simple", fake.FactoryFunc(prov))
-
-		crd := &v1alpha1.IngressMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-im",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.IngressMonitorSpec{
-				Provider: v1alpha1.NamespacedProvider{
-					Namespace: "testing",
-					ProviderSpec: v1alpha1.ProviderSpec{
-						Type: "simple",
-					},
-				},
-			},
-		}
-
-		// we'll never register the item, simulating that it's been deleted
-		crdClient := imfake.NewSimpleClientset()
-		op, _ := NewOperator(nil, crdClient, "", time.Minute, fact)
-
-		if err := op.handleIngressMonitor(namespaceKey(t, crd)); !kerrors.IsNotFound(err) {
-			t.Errorf("Expected no error, got %s", err)
-		}
-	})
-
-	t.Run("without registered provider", func(t *testing.T) {
-		fact := provider.NewFactory(nil)
-
-		prov := new(fake.SimpleProvider)
-		fact.Register("simple", fake.FactoryFunc(prov))
-
-		crd := &v1alpha1.IngressMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-im",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.IngressMonitorSpec{
-				Provider: v1alpha1.NamespacedProvider{
-					Namespace: "testing",
-					ProviderSpec: v1alpha1.ProviderSpec{
-						Type: "test",
-					},
-				},
-			},
-		}
-
-		crdClient := imfake.NewSimpleClientset(crd)
-		op, _ := NewOperator(nil, crdClient, "", time.Minute, fact)
-
-		expErr := errors.New("Error fetching provider 'test': the specified provider can't be found")
-		if err := op.handleIngressMonitor(namespaceKey(t, crd)); err.Error() != expErr.Error() {
-			t.Errorf("Expected error '%s', got '%s'", expErr, err)
-		}
-
-		if prov.UpdateCount != 0 {
-			t.Errorf("Expected no updates, got %d", prov.UpdateCount)
-		}
-
-		if prov.CreateCount != 0 {
-			t.Errorf("Expected no updates, got %d", prov.UpdateCount)
-		}
-	})
-
-	t.Run("with error updating monitor", func(t *testing.T) {
-		fact := provider.NewFactory(nil)
-
-		err := errors.New("my-provider-error")
-		prov := new(fake.SimpleProvider)
-		prov.UpdateFunc = func(status string, _ v1alpha1.MonitorTemplateSpec) (string, error) {
-			if status != "12345" {
-				t.Errorf("Expected status to be `12345`, got `%s`", status)
-			}
-			return status, err
-		}
-
-		fact.Register("simple", fake.FactoryFunc(prov))
-
-		crd := &v1alpha1.IngressMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-im",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.IngressMonitorSpec{
-				Provider: v1alpha1.NamespacedProvider{
-					Namespace: "testing",
-					ProviderSpec: v1alpha1.ProviderSpec{
-						Type: "simple",
-					},
-				},
-			},
-			Status: v1alpha1.IngressMonitorStatus{
-				ID: "12345",
-			},
-		}
-
-		crdClient := imfake.NewSimpleClientset(crd)
-		op, _ := NewOperator(nil, crdClient, "", time.Minute, fact)
-
-		if handleErr := op.handleIngressMonitor(namespaceKey(t, crd)); err != handleErr {
-			t.Errorf("Expected error '%s', got '%s'", err, handleErr)
-		}
-
-		if prov.UpdateCount != 1 {
-			t.Errorf("Expected Update to be called once, got %d", prov.UpdateCount)
-		}
-	})
-
-	t.Run("without errors", func(t *testing.T) {
-		fact := provider.NewFactory(nil)
-
-		prov := new(fake.SimpleProvider)
-		prov.UpdateFunc = func(status string, _ v1alpha1.MonitorTemplateSpec) (string, error) {
-			if status != "12345" {
-				t.Errorf("Expected status to be `12345`, got `%s`", status)
-			}
-			return status, nil
-		}
-
-		fact.Register("simple", fake.FactoryFunc(prov))
-
-		crd := &v1alpha1.IngressMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-im",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.IngressMonitorSpec{
-				Provider: v1alpha1.NamespacedProvider{
-					Namespace: "testing",
-					ProviderSpec: v1alpha1.ProviderSpec{
-						Type: "simple",
-					},
-				},
-			},
-			Status: v1alpha1.IngressMonitorStatus{
-				ID: "12345",
-			},
-		}
-
-		crdClient := imfake.NewSimpleClientset(crd)
-		op, _ := NewOperator(nil, crdClient, "", time.Minute, fact)
-
-		if err := op.handleIngressMonitor(namespaceKey(t, crd)); err != nil {
-			t.Errorf("Expected no error, got %s", err)
-		}
-
-		if prov.UpdateCount != 1 {
-			t.Errorf("Expected Update to be called once, got %d", prov.UpdateCount)
-		}
-	})
-}
-
-func TestOperator_OnDelete_IngressMonitor(t *testing.T) {
-	t.Run("without registered provider", func(t *testing.T) {
-		fact := provider.NewFactory(nil)
-		op, _ := NewOperator(nil, nil, "", time.Minute, fact)
-
-		prov := new(fake.SimpleProvider)
-		fact.Register("simple", fake.FactoryFunc(prov))
-
-		crd := &v1alpha1.IngressMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-im",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.IngressMonitorSpec{
-				Provider: v1alpha1.NamespacedProvider{
-					Namespace: "testing",
-					ProviderSpec: v1alpha1.ProviderSpec{
-						Type: "test",
-					},
-				},
-			},
-		}
-
-		op.OnDelete(crd)
-
-		if prov.DeleteCount != 0 {
-			t.Errorf("Expected no deletes, got %d", prov.DeleteCount)
-		}
-	})
-
-	t.Run("with error deleting monitor", func(t *testing.T) {
-		fact := provider.NewFactory(nil)
-
-		err := errors.New("my-provider-error")
-		prov := new(fake.SimpleProvider)
-		prov.DeleteFunc = func(status string) error {
-			if status != "12345" {
-				t.Errorf("Expected status to be `12345`, got `%s`", status)
-			}
-			return err
-		}
-
-		fact.Register("simple", fake.FactoryFunc(prov))
-		op, _ := NewOperator(nil, nil, "", time.Minute, fact)
-
-		crd := &v1alpha1.IngressMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-im",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.IngressMonitorSpec{
-				Provider: v1alpha1.NamespacedProvider{
-					Namespace: "testing",
-					ProviderSpec: v1alpha1.ProviderSpec{
-						Type: "simple",
-					},
-				},
-			},
-			Status: v1alpha1.IngressMonitorStatus{
-				ID: "12345",
-			},
-		}
-
-		op.OnDelete(crd)
-
-		if prov.DeleteCount != 1 {
-			t.Errorf("Expected delete to be called once, got %d", prov.DeleteCount)
-		}
-	})
-
-	t.Run("without errors", func(t *testing.T) {
-		fact := provider.NewFactory(nil)
-
-		prov := new(fake.SimpleProvider)
-		prov.DeleteFunc = func(status string) error {
-			if status != "12345" {
-				t.Errorf("Expected status to be `12345`, got `%s`", status)
-			}
-			return nil
-		}
-
-		fact.Register("simple", fake.FactoryFunc(prov))
-
-		crd := &v1alpha1.IngressMonitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-im",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.IngressMonitorSpec{
-				Provider: v1alpha1.NamespacedProvider{
-					Namespace: "testing",
-					ProviderSpec: v1alpha1.ProviderSpec{
-						Type: "simple",
-					},
-				},
-			},
-			Status: v1alpha1.IngressMonitorStatus{
-				ID: "12345",
-			},
-		}
-		op, _ := NewOperator(nil, nil, "", time.Minute, fact)
-
-		op.OnDelete(crd)
-
-		if prov.DeleteCount != 1 {
-			t.Errorf("Expected Update to be called once, got %d", prov.DeleteCount)
-		}
-	})
-}
-
-func TestOperator_OnDelete_Monitor(t *testing.T) {
-	im := &v1alpha1.IngressMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-im",
-			Namespace: "testing",
-			Labels: map[string]string{
-				monitorLabel: "delete-test-monitor",
-			},
-		},
-		Spec: v1alpha1.IngressMonitorSpec{
-			Provider: v1alpha1.NamespacedProvider{
-				Namespace: "testing",
-				ProviderSpec: v1alpha1.ProviderSpec{
-					Type: "simple",
-				},
-			},
-		},
-	}
-
-	mon := &v1alpha1.Monitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "delete-test-monitor",
-			Namespace: "testing",
-		},
-		Spec: v1alpha1.MonitorSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"team": "gophers",
-				},
-			},
-		},
-	}
-
-	crdClient := imfake.NewSimpleClientset(im, mon)
-	op, _ := NewOperator(nil, crdClient, v1.NamespaceAll, time.Minute, nil)
-
-	op.OnDelete(mon)
-
-	imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("Expected no error fetching IngressMonitors, got: %s", err)
-	}
-
-	if len(imList.Items) != 0 {
-		t.Errorf("Expected no IngressMonitors, got %d", len(imList.Items))
-	}
-}
-
-func TestOperator_HandleMonitor(t *testing.T) {
-	ing1 := &v1beta1.Ingress{
+func newIngress() *v1beta1.Ingress {
+	return &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "go-ingress",
 			Namespace: "testing",
@@ -613,416 +351,46 @@ func TestOperator_HandleMonitor(t *testing.T) {
 			},
 		},
 		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{
+				{
+					Hosts: []string{
+						"api.example.com",
+					},
+				},
+			},
 			Rules: []v1beta1.IngressRule{
 				{Host: "api.example.com"},
 			},
 		},
 	}
-	ing2 := &v1beta1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "node-ingress",
-			Namespace: "testing",
-			Labels: map[string]string{
-				"team": "reacters",
-			},
-		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{
-				{Host: "api.foo.com"},
-			},
-		},
-	}
+}
 
-	prov := &v1alpha1.Provider{
+func newProvider() *v1alpha1.Provider {
+	return &v1alpha1.Provider{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-provider",
 			Namespace: "testing",
 		},
 	}
-	tpl := &v1alpha1.MonitorTemplate{
+}
+
+func newIngressMonitor() *v1alpha1.IngressMonitor {
+	return &v1alpha1.IngressMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-template",
+			Name:      "test-im",
 			Namespace: "testing",
 		},
-		Spec: v1alpha1.MonitorTemplateSpec{
-			Type: "HTTP",
-			HTTP: &v1alpha1.HTTPTemplate{},
-		},
-	}
-
-	mon := &v1alpha1.Monitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-monitor",
-			Namespace: "testing",
-		},
-		Spec: v1alpha1.MonitorSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"team": "gophers",
+		Spec: v1alpha1.IngressMonitorSpec{
+			Provider: v1alpha1.NamespacedProvider{
+				Namespace: "testing",
+				ProviderSpec: v1alpha1.ProviderSpec{
+					Type: "simple",
 				},
-			},
-			Provider: v1.LocalObjectReference{
-				Name: "test-provider",
-			},
-			Template: v1.LocalObjectReference{
-				Name: "test-template",
 			},
 		},
 	}
-
-	var crdClient versioned.Interface
-	var k8sClient kubernetes.Interface
-	var op *Operator
-
-	setup := func() {
-		crdClient = imfake.NewSimpleClientset(prov, tpl)
-		mon, _ = crdClient.Ingressmonitor().Monitors(mon.Namespace).Create(mon)
-
-		k8sClient = k8sfake.NewSimpleClientset()
-		ing1, _ = k8sClient.Extensions().Ingresses(ing1.Namespace).Create(ing1)
-		ing2, _ = k8sClient.Extensions().Ingresses(ing2.Namespace).Create(ing2)
-
-		op, _ = NewOperator(k8sClient, crdClient, v1.NamespaceAll, time.Minute, provider.NewFactory(nil))
-		// we won't start the operator so the informers aren't automatically
-		// trigerred. Make sure the monitor is added correctly.
-		if err := op.handleMonitor(namespaceKey(t, mon)); err != nil {
-			t.Fatalf("Expected no error, got %s", err)
-		}
-	}
-
-	t.Run("without CRD changes", func(t *testing.T) {
-		t.Run("without Ingress changes", func(t *testing.T) {
-			setup()
-			if err := op.handleMonitor(namespaceKey(t, mon)); err != nil {
-				t.Fatalf("Expected no error, got %s", err)
-			}
-
-			imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("Expected no error listing IngressMonitors, got %s", err)
-			}
-
-			if len(imList.Items) != 1 {
-				t.Errorf("Expected 1 IngressMonitor, got %d", len(imList.Items))
-			}
-
-			if !metav1.IsControlledBy(&imList.Items[0], ing1) {
-				t.Errorf("Expected IngressMonitor to be owned by the correct Ingress")
-			}
-		})
-
-		t.Run("with Ingress changes", func(t *testing.T) {
-			setup()
-
-			// the user has changed the Ingress and removed the labels in their
-			// manifest
-			ing := ing1.DeepCopy()
-			ing.Labels = map[string]string{}
-			k8sClient.Extensions().Ingresses(ing.Namespace).Update(ing)
-
-			if err := op.handleMonitor(namespaceKey(t, mon)); err != nil {
-				t.Fatalf("Expected no error, got %s", err)
-			}
-
-			imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("Expected no error listing IngressMonitors, got %s", err)
-			}
-
-			if len(imList.Items) != 0 {
-				t.Errorf("Expected 0 IngressMonitor, got %d", len(imList.Items))
-			}
-		})
-
-		t.Run("with Ingress additions", func(t *testing.T) {
-			setup()
-
-			// the user has changed the Ingress and removed the labels in their
-			// manifest
-			ing := ing2.DeepCopy()
-			ing.Labels["team"] = "gophers"
-			k8sClient.Extensions().Ingresses(ing.Namespace).Update(ing)
-
-			if err := op.handleMonitor(namespaceKey(t, mon)); err != nil {
-				t.Fatalf("Expected no error, got %s", err)
-			}
-
-			imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("Expected no error listing IngressMonitors, got %s", err)
-			}
-
-			if len(imList.Items) != 2 {
-				t.Errorf("Expected 2 IngressMonitors, got %d", len(imList.Items))
-			}
-		})
-	})
-
-	t.Run("with CRD changes", func(t *testing.T) {
-		t.Run("to change Ingresses", func(t *testing.T) {
-			setup()
-
-			new := mon.DeepCopy()
-			new.Spec.Selector.MatchLabels["team"] = "reacters"
-			if err := op.handleMonitor(namespaceKey(t, new)); err != nil {
-				t.Fatalf("Expected no error, got %s", err)
-			}
-
-			imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("Expected no error listing IngressMonitors, got %s", err)
-			}
-
-			if len(imList.Items) != 1 {
-				t.Errorf("Expected 1 IngressMonitor, got %d", len(imList.Items))
-			}
-
-			if !metav1.IsControlledBy(&imList.Items[0], ing2) {
-				t.Errorf("Expected IngressMonitor to be owned by the correct Ingress")
-			}
-		})
-
-		t.Run("with the same Ingress", func(t *testing.T) {
-			setup()
-
-			new := mon.DeepCopy()
-			// add a new label which makes selection more specific
-			new.Spec.Selector.MatchLabels["squad"] = "operations"
-			if err := op.handleMonitor(namespaceKey(t, new)); err != nil {
-				t.Fatalf("Expected no error, got %s", err)
-			}
-
-			imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("Expected no error listing IngressMonitors, got %s", err)
-			}
-
-			if len(imList.Items) != 1 {
-				t.Errorf("Expected 1 IngressMonitor, got %d", len(imList.Items))
-			}
-
-			if !metav1.IsControlledBy(&imList.Items[0], ing1) {
-				t.Errorf("Expected IngressMonitor to be owned by the correct Ingress")
-			}
-		})
-
-		t.Run("with monitor already deleted", func(t *testing.T) {
-			// this could be caused by another delete action, we want to ensure
-			// that we handle this gracefully
-			setup()
-
-			err := crdClient.Ingressmonitor().Monitors(mon.Namespace).Delete(mon.Name, &metav1.DeleteOptions{})
-			if err != nil {
-				t.Fatalf("Could not delete Monitor: %s", err)
-			}
-
-			if err := op.handleMonitor(namespaceKey(t, mon)); !kerrors.IsNotFound(err) {
-				t.Fatalf("Expected no error, got %s", err)
-			}
-
-			imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("Expected no error listing IngressMonitors, got %s", err)
-			}
-
-			// The IngressMonitor is still active, we haven't called the
-			// OnDelete action yet
-			if len(imList.Items) != 1 {
-				t.Errorf("Expected 1 IngressMonitors, got %d", len(imList.Items))
-			}
-		})
-
-		t.Run("without matching Ingress", func(t *testing.T) {
-			setup()
-
-			// make sure we update the CRD in our fake store
-			new := mon.DeepCopy()
-			new.Spec.Selector.MatchLabels["non"] = "existing"
-			new, err := crdClient.Ingressmonitor().Monitors(new.Namespace).Update(new)
-			if err != nil {
-				t.Fatalf("Could not update labels: %s", err)
-			}
-
-			if err := op.handleMonitor(namespaceKey(t, new)); err != nil {
-				t.Fatalf("Expected no error, got %s", err)
-			}
-
-			imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).List(metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("Expected no error listing IngressMonitors, got %s", err)
-			}
-
-			if len(imList.Items) != 0 {
-				t.Errorf("Expected 0 IngressMonitors, got %d", len(imList.Items))
-			}
-		})
-
-		t.Run("with templating set up", func(t *testing.T) {
-			prov := &v1alpha1.Provider{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-provider",
-					Namespace: "testing",
-				},
-			}
-
-			tmpl := &v1alpha1.MonitorTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-template",
-					Namespace: "testing",
-				},
-				Spec: v1alpha1.MonitorTemplateSpec{
-					Name: "some-test-{{.IngressName}}-{{.IngressNamespace}}",
-					Type: "HTTP",
-					HTTP: &v1alpha1.HTTPTemplate{
-						Endpoint: ptrString("/_healthz"),
-					},
-				},
-			}
-
-			mon := &v1alpha1.Monitor{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-monitor",
-					Namespace: "testing",
-				},
-				Spec: v1alpha1.MonitorSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"team": "gophers",
-						},
-					},
-					Provider: v1.LocalObjectReference{
-						Name: "test-provider",
-					},
-					Template: v1.LocalObjectReference{
-						Name: "test-template",
-					},
-				},
-			}
-
-			crdClient := imfake.NewSimpleClientset(prov, tmpl, mon)
-			op, _ := NewOperator(k8sClient, crdClient, v1.NamespaceAll, time.Minute, provider.NewFactory(nil))
-
-			if err := op.handleMonitor(namespaceKey(t, mon)); err != nil {
-				t.Fatalf("Expected no error, got %s", err)
-			}
-
-			imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).
-				List(metav1.ListOptions{})
-			if err != nil {
-				t.Fatalf("Could not get IngressMonitor List: %s", err)
-			}
-
-			if len(imList.Items) != 1 {
-				t.Errorf("Expected 1 IngressMonitor to be registered, got %d", len(imList.Items))
-			}
-
-			// check if the templated name is parsed
-			expectedName := "some-test-go-ingress-testing"
-			if name := imList.Items[0].Spec.Template.Name; name != expectedName {
-				t.Errorf("Expected name to be `%s`, got `%s", expectedName, name)
-			}
-		})
-	})
-
-	t.Run("it should set up values correctly", func(t *testing.T) {
-		ing := &v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-ingress",
-				Namespace: "testing",
-				Labels: map[string]string{
-					"team": "gophers",
-				},
-			},
-			Spec: v1beta1.IngressSpec{
-				TLS: []v1beta1.IngressTLS{
-					{
-						Hosts: []string{
-							"test-host.sphc.io",
-						},
-					},
-				},
-				Rules: []v1beta1.IngressRule{
-					{Host: "test-host.sphc.io"},
-				},
-			},
-		}
-
-		k8sClient := k8sfake.NewSimpleClientset(ing)
-
-		prov := &v1alpha1.Provider{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-provider",
-				Namespace: "testing",
-			},
-		}
-
-		tmpl := &v1alpha1.MonitorTemplate{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-template",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.MonitorTemplateSpec{
-				Type: "HTTP",
-				HTTP: &v1alpha1.HTTPTemplate{
-					Endpoint: ptrString("/_healthz"),
-				},
-			},
-		}
-
-		mon := &v1alpha1.Monitor{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-monitor",
-				Namespace: "testing",
-			},
-			Spec: v1alpha1.MonitorSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"team": "gophers",
-					},
-				},
-				Provider: v1.LocalObjectReference{
-					Name: "test-provider",
-				},
-				Template: v1.LocalObjectReference{
-					Name: "test-template",
-				},
-			},
-		}
-
-		crdClient := imfake.NewSimpleClientset(prov, tmpl, mon)
-		op, _ := NewOperator(k8sClient, crdClient, v1.NamespaceAll, time.Minute, provider.NewFactory(nil))
-
-		if err := op.handleMonitor(namespaceKey(t, mon)); err != nil {
-			t.Fatalf("Expected no error, got %s", err)
-		}
-
-		imList, err := crdClient.Ingressmonitor().IngressMonitors(mon.Namespace).
-			List(metav1.ListOptions{})
-		if err != nil {
-			t.Fatalf("Could not get IngressMonitor List: %s", err)
-		}
-
-		if len(imList.Items) != 1 {
-			t.Errorf("Expected 1 IngressMonitor, got %d", len(imList.Items))
-		}
-
-		im := imList.Items[0]
-		expURL := "https://test-host.sphc.io/_healthz"
-		if url := im.Spec.Template.HTTP.URL; url != expURL {
-			t.Errorf("Expected URL to be `%s`, got `%s`", expURL, url)
-		}
-	})
 }
 
 func ptrString(s string) *string {
 	return &s
-}
-
-func namespaceKey(t *testing.T, obj interface{}) string {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		t.Fatalf("Could not get NamespaceKey for object %#v", obj)
-	}
-
-	return key
 }


### PR DESCRIPTION
This implements cache informers for syncs. This means that we put less
pressure on the APIServer by using a local cache to fetch objects.

This is particularly useful if we're seeing syncs that don't change much.

closes https://github.com/jelmersnoeck/ingress-monitor/issues/20
closes https://github.com/jelmersnoeck/ingress-monitor/issues/14