### PR TITLE
Make MonitorTemplate NamespaceScoped.

### DIFF
--- a/_examples/kuard/monitor-template.yaml
+++ b/_examples/kuard/monitor-template.yaml
@@ -2,6 +2,7 @@ apiVersion: ingressmonitor.sphc.io/v1alpha1
 kind: MonitorTemplate
 metadata:
   name: go-apps
+  namespace: websites
 spec:
   type: HTTP
   checkRate: 300s

--- a/apis/ingressmonitor/v1alpha1/monitortemplate.go
+++ b/apis/ingressmonitor/v1alpha1/monitortemplate.go
@@ -73,7 +73,6 @@ type HTTPTemplate struct {
 }
 
 // +genclient
-// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MonitorTemplate is the CRD specification for a MonitorTemplate. This

--- a/docs/kube/with-rbac.yaml
+++ b/docs/kube/with-rbac.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   group: ingressmonitor.sphc.io
   version: v1alpha1
-  scope: Cluster
+  scope: Namespaced
   names:
     plural: providers
     kind: Provider
@@ -30,7 +30,7 @@ metadata:
 spec:
   group: ingressmonitor.sphc.io
   version: v1alpha1
-  scope: Cluster
+  scope: Namespaced
   names:
     plural: monitortemplates
     kind: MonitorTemplate

--- a/internal/ingressmonitor/operator.go
+++ b/internal/ingressmonitor/operator.go
@@ -354,7 +354,7 @@ func (o *Operator) handleMonitor(key string) error {
 	}
 
 	// fetch the referenced template
-	tmpl, err := o.imClient.Ingressmonitor().MonitorTemplates().
+	tmpl, err := o.imClient.Ingressmonitor().MonitorTemplates(obj.Namespace).
 		Get(obj.Spec.Template.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("Could not get MonitorTemplate: %s", err)

--- a/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1/fake/fake_ingressmonitor_client.go
+++ b/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1/fake/fake_ingressmonitor_client.go
@@ -42,8 +42,8 @@ func (c *FakeIngressmonitorV1alpha1) Monitors(namespace string) v1alpha1.Monitor
 	return &FakeMonitors{c, namespace}
 }
 
-func (c *FakeIngressmonitorV1alpha1) MonitorTemplates() v1alpha1.MonitorTemplateInterface {
-	return &FakeMonitorTemplates{c}
+func (c *FakeIngressmonitorV1alpha1) MonitorTemplates(namespace string) v1alpha1.MonitorTemplateInterface {
+	return &FakeMonitorTemplates{c, namespace}
 }
 
 func (c *FakeIngressmonitorV1alpha1) Providers(namespace string) v1alpha1.ProviderInterface {

--- a/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1/fake/fake_monitortemplate.go
+++ b/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1/fake/fake_monitortemplate.go
@@ -37,6 +37,7 @@ import (
 // FakeMonitorTemplates implements MonitorTemplateInterface
 type FakeMonitorTemplates struct {
 	Fake *FakeIngressmonitorV1alpha1
+	ns   string
 }
 
 var monitortemplatesResource = schema.GroupVersionResource{Group: "ingressmonitor.sphc.io", Version: "v1alpha1", Resource: "monitortemplates"}
@@ -46,7 +47,8 @@ var monitortemplatesKind = schema.GroupVersionKind{Group: "ingressmonitor.sphc.i
 // Get takes name of the monitorTemplate, and returns the corresponding monitorTemplate object, and an error if there is any.
 func (c *FakeMonitorTemplates) Get(name string, options v1.GetOptions) (result *v1alpha1.MonitorTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(monitortemplatesResource, name), &v1alpha1.MonitorTemplate{})
+		Invokes(testing.NewGetAction(monitortemplatesResource, c.ns, name), &v1alpha1.MonitorTemplate{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -56,7 +58,8 @@ func (c *FakeMonitorTemplates) Get(name string, options v1.GetOptions) (result *
 // List takes label and field selectors, and returns the list of MonitorTemplates that match those selectors.
 func (c *FakeMonitorTemplates) List(opts v1.ListOptions) (result *v1alpha1.MonitorTemplateList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(monitortemplatesResource, monitortemplatesKind, opts), &v1alpha1.MonitorTemplateList{})
+		Invokes(testing.NewListAction(monitortemplatesResource, monitortemplatesKind, c.ns, opts), &v1alpha1.MonitorTemplateList{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -77,13 +80,15 @@ func (c *FakeMonitorTemplates) List(opts v1.ListOptions) (result *v1alpha1.Monit
 // Watch returns a watch.Interface that watches the requested monitorTemplates.
 func (c *FakeMonitorTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(monitortemplatesResource, opts))
+		InvokesWatch(testing.NewWatchAction(monitortemplatesResource, c.ns, opts))
+
 }
 
 // Create takes the representation of a monitorTemplate and creates it.  Returns the server's representation of the monitorTemplate, and an error, if there is any.
 func (c *FakeMonitorTemplates) Create(monitorTemplate *v1alpha1.MonitorTemplate) (result *v1alpha1.MonitorTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(monitortemplatesResource, monitorTemplate), &v1alpha1.MonitorTemplate{})
+		Invokes(testing.NewCreateAction(monitortemplatesResource, c.ns, monitorTemplate), &v1alpha1.MonitorTemplate{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -93,7 +98,8 @@ func (c *FakeMonitorTemplates) Create(monitorTemplate *v1alpha1.MonitorTemplate)
 // Update takes the representation of a monitorTemplate and updates it. Returns the server's representation of the monitorTemplate, and an error, if there is any.
 func (c *FakeMonitorTemplates) Update(monitorTemplate *v1alpha1.MonitorTemplate) (result *v1alpha1.MonitorTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(monitortemplatesResource, monitorTemplate), &v1alpha1.MonitorTemplate{})
+		Invokes(testing.NewUpdateAction(monitortemplatesResource, c.ns, monitorTemplate), &v1alpha1.MonitorTemplate{})
+
 	if obj == nil {
 		return nil, err
 	}
@@ -103,13 +109,14 @@ func (c *FakeMonitorTemplates) Update(monitorTemplate *v1alpha1.MonitorTemplate)
 // Delete takes name of the monitorTemplate and deletes it. Returns an error if one occurs.
 func (c *FakeMonitorTemplates) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(monitortemplatesResource, name), &v1alpha1.MonitorTemplate{})
+		Invokes(testing.NewDeleteAction(monitortemplatesResource, c.ns, name), &v1alpha1.MonitorTemplate{})
+
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeMonitorTemplates) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(monitortemplatesResource, listOptions)
+	action := testing.NewDeleteCollectionAction(monitortemplatesResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.MonitorTemplateList{})
 	return err
@@ -118,7 +125,8 @@ func (c *FakeMonitorTemplates) DeleteCollection(options *v1.DeleteOptions, listO
 // Patch applies the patch and returns the patched monitorTemplate.
 func (c *FakeMonitorTemplates) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.MonitorTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(monitortemplatesResource, name, data, subresources...), &v1alpha1.MonitorTemplate{})
+		Invokes(testing.NewPatchSubresourceAction(monitortemplatesResource, c.ns, name, data, subresources...), &v1alpha1.MonitorTemplate{})
+
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1/ingressmonitor_client.go
+++ b/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1/ingressmonitor_client.go
@@ -52,8 +52,8 @@ func (c *IngressmonitorV1alpha1Client) Monitors(namespace string) MonitorInterfa
 	return newMonitors(c, namespace)
 }
 
-func (c *IngressmonitorV1alpha1Client) MonitorTemplates() MonitorTemplateInterface {
-	return newMonitorTemplates(c)
+func (c *IngressmonitorV1alpha1Client) MonitorTemplates(namespace string) MonitorTemplateInterface {
+	return newMonitorTemplates(c, namespace)
 }
 
 func (c *IngressmonitorV1alpha1Client) Providers(namespace string) ProviderInterface {

--- a/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1/monitortemplate.go
+++ b/pkg/client/generated/clientset/versioned/typed/ingressmonitor/v1alpha1/monitortemplate.go
@@ -36,7 +36,7 @@ import (
 // MonitorTemplatesGetter has a method to return a MonitorTemplateInterface.
 // A group's client should implement this interface.
 type MonitorTemplatesGetter interface {
-	MonitorTemplates() MonitorTemplateInterface
+	MonitorTemplates(namespace string) MonitorTemplateInterface
 }
 
 // MonitorTemplateInterface has methods to work with MonitorTemplate resources.
@@ -55,12 +55,14 @@ type MonitorTemplateInterface interface {
 // monitorTemplates implements MonitorTemplateInterface
 type monitorTemplates struct {
 	client rest.Interface
+	ns     string
 }
 
 // newMonitorTemplates returns a MonitorTemplates
-func newMonitorTemplates(c *IngressmonitorV1alpha1Client) *monitorTemplates {
+func newMonitorTemplates(c *IngressmonitorV1alpha1Client, namespace string) *monitorTemplates {
 	return &monitorTemplates{
 		client: c.RESTClient(),
+		ns:     namespace,
 	}
 }
 
@@ -68,6 +70,7 @@ func newMonitorTemplates(c *IngressmonitorV1alpha1Client) *monitorTemplates {
 func (c *monitorTemplates) Get(name string, options v1.GetOptions) (result *v1alpha1.MonitorTemplate, err error) {
 	result = &v1alpha1.MonitorTemplate{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("monitortemplates").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -80,6 +83,7 @@ func (c *monitorTemplates) Get(name string, options v1.GetOptions) (result *v1al
 func (c *monitorTemplates) List(opts v1.ListOptions) (result *v1alpha1.MonitorTemplateList, err error) {
 	result = &v1alpha1.MonitorTemplateList{}
 	err = c.client.Get().
+		Namespace(c.ns).
 		Resource("monitortemplates").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -91,6 +95,7 @@ func (c *monitorTemplates) List(opts v1.ListOptions) (result *v1alpha1.MonitorTe
 func (c *monitorTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
+		Namespace(c.ns).
 		Resource("monitortemplates").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -100,6 +105,7 @@ func (c *monitorTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *monitorTemplates) Create(monitorTemplate *v1alpha1.MonitorTemplate) (result *v1alpha1.MonitorTemplate, err error) {
 	result = &v1alpha1.MonitorTemplate{}
 	err = c.client.Post().
+		Namespace(c.ns).
 		Resource("monitortemplates").
 		Body(monitorTemplate).
 		Do().
@@ -111,6 +117,7 @@ func (c *monitorTemplates) Create(monitorTemplate *v1alpha1.MonitorTemplate) (re
 func (c *monitorTemplates) Update(monitorTemplate *v1alpha1.MonitorTemplate) (result *v1alpha1.MonitorTemplate, err error) {
 	result = &v1alpha1.MonitorTemplate{}
 	err = c.client.Put().
+		Namespace(c.ns).
 		Resource("monitortemplates").
 		Name(monitorTemplate.Name).
 		Body(monitorTemplate).
@@ -122,6 +129,7 @@ func (c *monitorTemplates) Update(monitorTemplate *v1alpha1.MonitorTemplate) (re
 // Delete takes name of the monitorTemplate and deletes it. Returns an error if one occurs.
 func (c *monitorTemplates) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("monitortemplates").
 		Name(name).
 		Body(options).
@@ -132,6 +140,7 @@ func (c *monitorTemplates) Delete(name string, options *v1.DeleteOptions) error 
 // DeleteCollection deletes a collection of objects.
 func (c *monitorTemplates) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
+		Namespace(c.ns).
 		Resource("monitortemplates").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -143,6 +152,7 @@ func (c *monitorTemplates) DeleteCollection(options *v1.DeleteOptions, listOptio
 func (c *monitorTemplates) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.MonitorTemplate, err error) {
 	result = &v1alpha1.MonitorTemplate{}
 	err = c.client.Patch(pt).
+		Namespace(c.ns).
 		Resource("monitortemplates").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/generated/informers/externalversions/ingressmonitor/v1alpha1/interface.go
+++ b/pkg/client/generated/informers/externalversions/ingressmonitor/v1alpha1/interface.go
@@ -63,7 +63,7 @@ func (v *version) Monitors() MonitorInformer {
 
 // MonitorTemplates returns a MonitorTemplateInformer.
 func (v *version) MonitorTemplates() MonitorTemplateInformer {
-	return &monitorTemplateInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &monitorTemplateInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // Providers returns a ProviderInformer.

--- a/pkg/client/generated/informers/externalversions/ingressmonitor/v1alpha1/monitortemplate.go
+++ b/pkg/client/generated/informers/externalversions/ingressmonitor/v1alpha1/monitortemplate.go
@@ -47,32 +47,33 @@ type MonitorTemplateInformer interface {
 type monitorTemplateInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	namespace        string
 }
 
 // NewMonitorTemplateInformer constructs a new informer for MonitorTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewMonitorTemplateInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredMonitorTemplateInformer(client, resyncPeriod, indexers, nil)
+func NewMonitorTemplateInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredMonitorTemplateInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredMonitorTemplateInformer constructs a new informer for MonitorTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredMonitorTemplateInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredMonitorTemplateInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.IngressmonitorV1alpha1().MonitorTemplates().List(options)
+				return client.IngressmonitorV1alpha1().MonitorTemplates(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.IngressmonitorV1alpha1().MonitorTemplates().Watch(options)
+				return client.IngressmonitorV1alpha1().MonitorTemplates(namespace).Watch(options)
 			},
 		},
 		&ingressmonitorv1alpha1.MonitorTemplate{},
@@ -82,7 +83,7 @@ func NewFilteredMonitorTemplateInformer(client versioned.Interface, resyncPeriod
 }
 
 func (f *monitorTemplateInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredMonitorTemplateInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredMonitorTemplateInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *monitorTemplateInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/generated/listers/ingressmonitor/v1alpha1/expansion_generated.go
+++ b/pkg/client/generated/listers/ingressmonitor/v1alpha1/expansion_generated.go
@@ -44,6 +44,10 @@ type MonitorNamespaceListerExpansion interface{}
 // MonitorTemplateLister.
 type MonitorTemplateListerExpansion interface{}
 
+// MonitorTemplateNamespaceListerExpansion allows custom methods to be added to
+// MonitorTemplateNamespaceLister.
+type MonitorTemplateNamespaceListerExpansion interface{}
+
 // ProviderListerExpansion allows custom methods to be added to
 // ProviderLister.
 type ProviderListerExpansion interface{}


### PR DESCRIPTION
We'll add a `ClusterMonitorTemplate` later on. This should default to
a namespace scoped resource.