### PR TITLE
Add health endpoint.

### DIFF
--- a/docs/kube/with-rbac.yaml
+++ b/docs/kube/with-rbac.yaml
@@ -145,6 +145,26 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
           - operator
+          livenessProbe:
+            httpGet:
+              path: /_healthz
+              port: 9090
+              scheme: HTTP
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 50
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /_healthz
+              port: 9090
+              scheme: HTTP
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
             requests:
               cpu: 1m

--- a/internal/httpsvc/health.go
+++ b/internal/httpsvc/health.go
@@ -1,0 +1,25 @@
+package httpsvc
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Health represents a Health server which can be used to expose a health check.
+type Health struct {
+	Server
+}
+
+// Start starts the Health Server.
+func (s *Health) Start(stopCh <-chan struct{}) error {
+	registerHealthCheck(&s.ServeMux)
+
+	return s.Server.Start(stopCh)
+}
+
+func registerHealthCheck(mux *http.ServeMux) {
+	mux.HandleFunc("/_healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+	})
+}

--- a/internal/httpsvc/server.go
+++ b/internal/httpsvc/server.go
@@ -1,0 +1,38 @@
+package httpsvc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Server is a wrapper around a http.ServeMux which sets up necessary endpoints
+// to run our operator.
+type Server struct {
+	http.ServeMux
+
+	Addr string
+	Port int
+}
+
+// Start starts the HTTP Server.
+func (s *Server) Start(stopCh <-chan struct{}) error {
+	srv := http.Server{
+		Addr:         fmt.Sprintf("%s:%d", s.Addr, s.Port),
+		Handler:      &s.ServeMux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		<-stopCh
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		srv.Shutdown(ctx)
+	}()
+
+	return srv.ListenAndServe()
+}


### PR DESCRIPTION
By adding the healthz endpoint, we can introduce readiness and liveness
probes. This assures that our pod is running.

closes https://github.com/jelmersnoeck/ingress-monitor/issues/27